### PR TITLE
feat: retry logic with exponential backoff for failed HTTP requests

### DIFF
--- a/pkg/scraper/retry.go
+++ b/pkg/scraper/retry.go
@@ -1,0 +1,84 @@
+package scraper
+
+import (
+	"errors"
+	"net/http"
+	"time"
+)
+
+// retryableError wraps the last error after all attempts are exhausted.
+type retryableError struct {
+	attempts int
+	err      error
+}
+
+func (e *retryableError) Error() string { return e.err.Error() }
+func (e *retryableError) Unwrap() error { return e.err }
+
+// isRetryable returns true for errors worth retrying:
+//   - any network/timeout error from http.Client.Do
+//   - HTTP 429 Too Many Requests
+//   - HTTP 5xx server errors
+func isRetryable(err error, statusCode int) bool {
+	if err != nil {
+		return true // covers timeouts, connection resets, DNS failures
+	}
+	return statusCode == http.StatusTooManyRequests || statusCode >= 500
+}
+
+// withRetry calls do up to maxRetries times with exponential backoff between attempts.
+//
+// Backoff schedule (baseDelay = 300ms):
+//
+//	attempt 0 fails → wait 300ms  → attempt 1
+//	attempt 1 fails → wait 600ms  → attempt 2
+//	attempt 2 fails → wait 1200ms → attempt 3  (last)
+//
+// Returns immediately on the first success or non-retryable error.
+// Respects Retry-After header on 429 responses.
+func withRetry(maxRetries int, baseDelay time.Duration, do func() (*http.Response, error)) (*http.Response, error) {
+	var (
+		resp *http.Response
+		err  error
+	)
+
+	for attempt := range maxRetries {
+		resp, err = do()
+
+		// Success — no error and status is not retryable.
+		if err == nil && !isRetryable(nil, resp.StatusCode) {
+			return resp, nil
+		}
+
+		// Close body before retry to avoid leaking connections.
+		if resp != nil {
+			resp.Body.Close()
+		}
+
+		// Last attempt — don't sleep, fall through to return the error.
+		if attempt == maxRetries-1 {
+			break
+		}
+
+		// Exponential backoff: baseDelay * 2^attempt
+		sleep := baseDelay * (1 << attempt)
+
+		// Honour Retry-After header if the server sent one (common with 429).
+		if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+			if ra := resp.Header.Get("Retry-After"); ra != "" {
+				if secs, parseErr := time.ParseDuration(ra + "s"); parseErr == nil {
+					sleep = secs
+				}
+			}
+		}
+
+		time.Sleep(sleep)
+	}
+
+	// Wrap the last error with attempt count for observability.
+	lastErr := err
+	if lastErr == nil {
+		lastErr = errors.New(resp.Status)
+	}
+	return nil, &retryableError{attempts: maxRetries, err: lastErr}
+}

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -60,18 +60,22 @@ type BulkScrapeResponse struct {
 // Config holds tunables for the worker pool and HTTP client.
 type Config struct {
 	WorkerCount       int           // number of concurrent worker goroutines
-	RateLimit         float64       // maximum requests per second across all workers (e.g. 5 = 5 req/s)
+	RateLimit         float64       // maximum requests per second across all workers
 	MaxURLsPerRequest int           // hard cap on URLs per call
 	HTTPTimeout       time.Duration // per-request HTTP timeout
+	MaxRetries        int           // max retry attempts on failure (0 = no retries)
+	BaseRetryDelay    time.Duration // initial backoff delay; doubles each attempt
 }
 
 // DefaultConfig returns sensible production defaults.
 func DefaultConfig() Config {
 	return Config{
 		WorkerCount:       6,
-		RateLimit:         5, // 5 req/s → one request every 200ms globally
+		RateLimit:         5,
 		MaxURLsPerRequest: 25,
 		HTTPTimeout:       12 * time.Second,
+		MaxRetries:        3,
+		BaseRetryDelay:    300 * time.Millisecond,
 	}
 }
 
@@ -95,6 +99,12 @@ func NewClient(cfg Config) *Client {
 	if cfg.MaxURLsPerRequest <= 0 {
 		cfg.MaxURLsPerRequest = 25
 	}
+	if cfg.MaxRetries <= 0 {
+		cfg.MaxRetries = 3
+	}
+	if cfg.BaseRetryDelay <= 0 {
+		cfg.BaseRetryDelay = 300 * time.Millisecond
+	}
 	return &Client{
 		httpClient: &http.Client{Timeout: cfg.HTTPTimeout},
 		cfg:        cfg,
@@ -106,16 +116,20 @@ func (c *Client) MaxURLs() int { return c.cfg.MaxURLsPerRequest }
 
 // --- Core fetch logic ---
 
-// fetch performs a single HTTP GET, parses the HTML, and returns matched elements.
+// fetch performs an HTTP GET with automatic retry + exponential backoff.
+// It retries on network errors, timeouts, 429, and 5xx responses (up to maxRetries).
 // This is the fetchFn passed to the worker pool.
 func (c *Client) fetch(ctx context.Context, pageURL, selector string) ([]ScrapeResult, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	res, err := c.httpClient.Do(req)
+
+	res, err := withRetry(c.cfg.MaxRetries, c.cfg.BaseRetryDelay, func() (*http.Response, error) {
+		return c.httpClient.Do(req)
+	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", pageURL, err)
 	}
 	defer res.Body.Close()
 


### PR DESCRIPTION
- Add pkg/scraper/retry.go: withRetry(maxRetries, baseDelay, do)
- Retries on: network errors, timeouts, HTTP 429, HTTP 5xx
- Backoff: baseDelay * 2^attempt (300ms, 600ms, 1200ms by default)
- Respects Retry-After header on 429 responses
- Config gains MaxRetries (default 3) and BaseRetryDelay (default 300ms)
- fetch() passes cfg values into withRetry — fully configurable per client